### PR TITLE
Limit log avg_loss and time log accuracy to 4 digits

### DIFF
--- a/auto_gptq_next/models/_base.py
+++ b/auto_gptq_next/models/_base.py
@@ -310,7 +310,8 @@ class BaseGPTQForCausalLM(nn.Module, PushToHubMixin):
                             static_groups=self.quantize_config.static_groups,
                         )
 
-                        stat = {"layer": i + 1, "module": name, "avg_loss": avg_loss, "time": duration}
+                        stat = {"layer": i + 1, "module": name, "avg_loss": f"{avg_loss:.4f}",
+                                "time": f"{duration:.4f}"}
 
                         quant_log.append(stat)
                         logger.info(stat)


### PR DESCRIPTION
Reduce non-human readable numbers for avg_loss and time per layer during quantization stage.